### PR TITLE
Добавлено хранение истории сообщений в файлах

### DIFF
--- a/client/src/main/java/client/Controller.java
+++ b/client/src/main/java/client/Controller.java
@@ -56,6 +56,9 @@ public class Controller implements Initializable {
     private Stage regStage;
     private  RegControler regControler;
 
+    private String login;
+    private FileHistoryService fileHistoryService = new FileHistoryService();
+
     public void setAuthenticated(boolean authenticated) {
         this.authenticated = authenticated;
         authPanel.setVisible(!authenticated);
@@ -67,6 +70,7 @@ public class Controller implements Initializable {
 
         if(!authenticated) {
             nickname = "";
+            fileHistoryService.close();
         }
         setTitle(nickname);
         textArea.clear();
@@ -110,6 +114,8 @@ public class Controller implements Initializable {
                                 nickname = str.split("\\s+")[1];
                                 setAuthenticated(true);
 
+                                textArea.appendText(fileHistoryService.loadLast100Message(login));
+
                                 break;
                             }
                             if (str.startsWith("/reg_ok")) {
@@ -146,6 +152,7 @@ public class Controller implements Initializable {
                             }
                         } else {
                             textArea.appendText(str + "\n");
+                            fileHistoryService.saveHistoryRow(str + "\n");
                         }
                     }
                 } catch (IOException e) {
@@ -183,6 +190,8 @@ public class Controller implements Initializable {
             connect();
         }
         String msg = String.format("/auth %s %s", loginField.getText().trim(), passwordField.getText().trim());
+
+        login = loginField.getText().trim();
 
         try {
             out.writeUTF(msg);

--- a/client/src/main/java/client/FileHistoryService.java
+++ b/client/src/main/java/client/FileHistoryService.java
@@ -1,0 +1,106 @@
+package client;
+
+import javax.swing.*;
+import java.io.*;
+import java.util.ArrayDeque;
+
+public class FileHistoryService {
+    private File fileHistory;
+    FileWriter fileWriter;
+    FileReader fileReader;
+    BufferedReader bufferedReader;
+    BufferedWriter bufferedWriter;
+
+    /**
+     * Подготовка названия файла и проверка на наличие файла
+     * @param login логин пользователя
+     * @return true если нужный файл существует, иначе false
+     */
+    public boolean prepareFile (String login) {
+        fileHistory = new File(String.format("history/history_%s.txt", login));
+        return fileHistory.exists();
+    }
+
+    /**
+     * Метод чтения одной строки из файла
+     */
+    public String loadHistoryRow() throws IOException {
+        if(fileReader == null) {
+            fileReader = new FileReader(fileHistory);
+            bufferedReader = new BufferedReader(fileReader);
+        }
+
+        return bufferedReader.readLine();
+    }
+
+    /**
+     * Метод записи в файл сообщения
+     * @param msg сообщение
+     */
+    public void saveHistoryRow(String msg){
+        try {
+            if(fileWriter == null) {
+                fileWriter = new FileWriter(fileHistory, true);
+            }
+
+            fileWriter.write(msg);
+            fileWriter.flush();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Метод, закрывающий доступ к файлам
+     */
+    public void close(){
+        try {
+            if(fileWriter != null) {
+
+                    fileWriter.close();
+            }
+            if(bufferedReader != null) {
+                bufferedReader.close();
+            }
+            if (fileReader != null) {
+                fileReader.close();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Метод получения 100 последних строк из файла
+     * @param login логи пользователя
+     * @return 100 последних сообщений
+     */
+    public String loadLast100Message(String login) {
+        if(!prepareFile(login)) {
+            return "";
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+        String row;
+        try {
+            ArrayDeque<String> arrayDeque = new ArrayDeque<>();
+
+            while ((row = loadHistoryRow()) != null) {
+                arrayDeque.addLast(row);
+                //если записанная строка 101я, то удаляем первый элемент очереди
+                if(arrayDeque.size() > 100) {
+                    arrayDeque.removeFirst();
+                }
+            }
+
+            while(!arrayDeque.isEmpty()) {
+                stringBuilder.append(arrayDeque.pollFirst()).append("\n");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return stringBuilder.toString();
+    }
+}


### PR DESCRIPTION
Урок 3. Средства ввода-вывода
1. Добавить в сетевой чат запись локальной истории в текстовый файл на клиенте. Для каждой учетной записи файл с историей должен называться history_[login].txt. (Например, history_login1.txt, history_user111.txt)
2.** После загрузки клиента показывать ему последние 100 строк истории чата.